### PR TITLE
feat: añadir disponibilidad y asignación de sesiones en formulario de places

### DIFF
--- a/models/reservable/place.py
+++ b/models/reservable/place.py
@@ -2,27 +2,77 @@ from odoo import models, fields, api, _
 from odoo.exceptions import UserError
 
 class Place(models.Model):
-  _name = 'maya_core.place'
-  _inherit = ['maya_core.place', 'maya_booking.reservable.mixin']
+    _name = 'maya_core.place'
+    _inherit = ['maya_core.place', 'maya_booking.reservable.mixin']
 
+    @api.depends('name', 'location_id')
+    def _compute_display_name(self):
+        for record in self:
+            if not record.name:
+                record.display_name = _("Sin recurso")
+            elif not record.location_id:
+                record.display_name = record.name
+            else:
+                record.display_name = f"{record.name} - [{record.location_id.name}]"
 
-  @api.depends('name', 'location_id')
-  def _compute_display_name(self):
-    for record in self:
-      if record:
-        record.display_name = record.name + " - [" + record.location_id.name + "]"
-      else:
-        record.display_name = _("Sin recurso")
+    def unlink(self):
+        for record in self:
+            reservas = self.env["maya_booking.booking"].search_count(
+                [("place_id", "=", record.id)]
+            )
+            if reservas > 0:
+                raise UserError(
+                    _("No se puede eliminar el espacio '%s' porque tiene reservas asociadas.") % record.name
+                )
+        
+        return super().unlink()
 
-
-  def unlink(self):
-    for record in self:
-      reservas = self.env["maya_booking.booking"].search_count(
-        [("place_id", "=", record.id)]
-      )
-      if reservas > 0:
-        raise UserError(
-            _("No se puede eliminar el espacio '%s' porque tiene reservas asociadas.") % record.name
+    availability_grid_html = fields.Html(
+            string="Cuadrante de Horarios", 
+            compute="_compute_availability_grid_html",
+            sanitize=False 
         )
-      
-    return super().unlink()
+
+    @api.depends('location_id', 'session_schedule_ids')
+    def _compute_availability_grid_html(self):
+        for record in self:
+            if not record.location_id:
+                record.availability_grid_html = "<div class='alert alert-warning'>Seleccione una ubicación para cargar el cuadrante.</div>"
+                continue
+
+            # Todas las sesiones posibles de la ubicación
+            all_location_schedules = self.env['maya_core.session_schedule'].search([
+                ('location_id', '=', record.location_id.id),
+                ('active', '=', True)
+            ])
+
+            # IDs de las sesiones previamente asignadas a este espacio
+            assigned_ids = record.session_schedule_ids.ids
+
+            days = ['0L', '1M', '2X', '3J', '4V']
+            schedules_by_day = {day: [] for day in days}
+            
+            for schedule in all_location_schedules:
+                # Calculamos horas
+                start_h = int(schedule.start_time)
+                start_m = int(round((schedule.start_time - start_h) * 60))
+                end_h = int(schedule.end_time)
+                end_m = int(round((schedule.end_time - end_h) * 60))
+                
+                schedules_by_day[schedule.week_day].append({
+                    'name': schedule.name,
+                    'time_str': f"{start_h:02d}:{start_m:02d} - {end_h:02d}:{end_m:02d}",
+                    'start_time': schedule.start_time,
+                    'is_assigned': schedule.id in assigned_ids 
+                })
+
+            for day in days:
+                schedules_by_day[day] = sorted(schedules_by_day[day], key=lambda x: x['start_time'])
+
+            values = {
+                'days': days,
+                'day_names': {'0L': 'Lunes', '1M': 'Martes', '2X': 'Miércoles', '3J': 'Jueves', '4V': 'Viernes'},
+                'schedules_by_day': schedules_by_day,
+            }
+
+            record.availability_grid_html = self.env['ir.qweb']._render('maya_booking.template_cuadrante_horarios', values)

--- a/views/views.xml
+++ b/views/views.xml
@@ -10,15 +10,17 @@
         <field name="name"/>
         <templates>
           <t t-name="card">
-            <div class="oe_kanban_global_click w-100 d-flex align-items-center justify-content-between p-3 mb-1">
+            <div class="oe_kanban_global_click w-100 d-flex align-items-center justify-content-between p-3 mb-1 position-relative overflow-hidden">
               
+              <div class="mi-ribbon-reserva">Reserva</div>
+
               <div class="d-flex align-items-center">
                 <span class="fw-bold fs-5">
                   <field name="name"/>
                 </span>
               </div>
 
-              <div class="d-flex gap-2">
+              <div class="d-flex gap-2 me-5">
                 <button class="btn btn-sm btn-secondary" title="Publicar">Publicar</button>
                 <button type="open" class="btn btn-sm btn-primary" title="Editar">Editar</button>
               </div>
@@ -28,7 +30,7 @@
         </templates>
       </kanban>
     </field>
-</record>
+  </record>
 
 <record id="maya_booking.view_booking_type_form" model="ir.ui.view">
   <field name="name">maya_booking.booking_type.form</field>
@@ -151,6 +153,81 @@
         </timeline>
       </field>
     </record>
+
+<record id="view_place_form_inherit_booking" model="ir.ui.view">
+        <field name="name">maya_core.place.form.inherit.booking</field>
+        <field name="model">maya_core.place</field>
+        <field name="inherit_id" ref="maya_core.view_place_form"/>
+        <field name="arch" type="xml">
+            
+            <xpath expr="//notebook" position="inside">
+                
+                <page string="Asignar Sesiones">
+                    <field name="session_schedule_ids" domain="[('location_id', '=', location_id)]"/>
+                </page>
+
+                <page string="Sesiones Disponibles">
+                    <field name="availability_grid_html" readonly="1" nolabel="1"/>
+                </page>
+
+            </xpath>
+
+        </field>
+    </record>
+
+    <template id="template_cuadrante_horarios" name="Cuadrante de Horarios">
+        <div style="max-width: 90%; margin-right: auto;">
+            <table class="table table-bordered text-center mb-0" style="width: 100%; table-layout: fixed; border-collapse: separate; border-spacing: 4px;">
+                <thead class="bg-light">
+                    <tr>
+                        <th class="py-2 text-uppercase text-muted" style="font-size: 0.8em; border: none; width: 140px;">Horario</th>
+                        
+                        <t t-foreach="days" t-as="day">
+                            <th class="py-2 text-uppercase text-muted" style="font-size: 0.8em; border: none;" t-esc="day_names[day]"/>
+                        </t>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td style="vertical-align: top; background-color: #ffffff; border: none; padding: 8px;">
+                            <t t-set="ref_schedules" t-value="schedules_by_day[days[0]]"/>
+                            <t t-if="ref_schedules">
+                                <t t-foreach="ref_schedules" t-as="rs">
+                                    <div class="card mb-2 border-0 shadow-none bg-transparent">
+                                        <div class="card-body p-2 d-flex align-items-center justify-content-center" style="min-height: 42px;">
+                                            <strong class="text-muted" style="font-size: 0.85em;" t-esc="rs.get('time_str', '')"/>
+                                        </div>
+                                    </div>
+                                </t>
+                            </t>
+                        </td>
+
+                        <t t-foreach="days" t-as="day">
+                            <td style="vertical-align: top; background-color: #f8f9fa; border: none; border-radius: 4px; padding: 8px;">
+                                <t t-set="day_schedules" t-value="schedules_by_day[day]"/>
+                                
+                                <t t-if="not day_schedules">
+                                    <small class="text-black-50" style="font-size: 0.7em;">Sin sesiones en edificio</small>
+                                </t>
+                                <t t-else=""> 
+                                    <t t-foreach="day_schedules" t-as="s">
+                                        <t t-set="card_style" t-value="'background-color: #8abc8c; color: white;' if s['is_assigned'] else 'background-color: #e9ecef; color: #6c757d; opacity: 0.6;'"/>
+                                        <t t-set="border_style" t-value="'border-left: 4px solid #1e7e34;' if s['is_assigned'] else 'border-left: 4px solid #dee2e6;'"/>
+                                        
+                                        <div t-att-style="card_style + border_style" class="card mb-2 border-0 shadow-sm">
+                                            <div class="card-body p-2 d-flex align-items-center justify-content-center" style="min-height: 42px;">
+                                                <strong class="d-block" style="font-size: 0.85em;" t-esc="s['name']"/>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </t>
+                            </td>
+                        </t>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </template>
 
     <record id="maya_booking.action_booking_type" model="ir.actions.act_window">
       <field name="name">Tipos de reserva</field>


### PR DESCRIPTION
He añadido una vista formulario de places heredada de maya_core en la que he puesto dos nuevas páginas dentro del notebook, una para mostrar las sesiones disponibles del espacio (con un calendario mapeado en html) y otra para la asignación de sesiones (con una lista simple del many2many con session_schedule).

Dentro de models/reservable/places.py (modelo heredado del places.py de maya_core) he añadido un nuevo campo availability_grid_html y un compute para calcular y mostrar las sesiones asignadas en la vista.