### PR TITLE
feat: añadido endpoint api booking_types

### DIFF
--- a/controllers/controllers.py
+++ b/controllers/controllers.py
@@ -16,8 +16,8 @@ class MayaBookingApi(http.Controller):
         data = []
         for rec in tipos_reserva:
             image_url = False
-            if hasattr(rec, 'image_1920') and rec.image_1920:
-                image_url = f"{base_url}/web/image/maya_booking.booking_type/{rec.id}/image_1920"
+            if hasattr(rec, 'image_icon') and rec.image_icon:
+                image_url = f"{base_url}/web/image/maya_booking.booking_type/{rec.id}/image_icon"
 
             data.append({
                 'id': rec.id,

--- a/controllers/controllers.py
+++ b/controllers/controllers.py
@@ -1,6 +1,40 @@
-# from odoo import http
+from odoo import http
+from odoo.http import request
 
+class MayaBookingApi(http.Controller):
 
+    @http.route('/api/booking_types', type='json', auth='public', methods=['POST'], csrf=False)
+    def get_booking_types(self, **kwargs):
+        """
+        Devuelve los tipos de reserva publicados para usarlos fuera del ERP.
+        """
+        domain = [('published', '=', True)]
+        tipos_reserva = request.env['maya_booking.booking_type'].sudo().search(domain)
+
+        base_url = request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        
+        data = []
+        for rec in tipos_reserva:
+            image_url = False
+            if hasattr(rec, 'image_1920') and rec.image_1920:
+                image_url = f"{base_url}/web/image/maya_booking.booking_type/{rec.id}/image_1920"
+
+            data.append({
+                'id': rec.id,
+                'name': rec.name,
+                'description': rec.description or '',
+                'duration': rec.duration,
+                'resource_type': rec.resource_type,
+                'resource_count': rec.resource_count,
+                'resource_ids': rec.resource_ids.ids, 
+                'image_url': image_url,
+            })
+
+        return {
+            'status': 200,
+            'message': 'Success',
+            'data': data
+        }
 # class MayaCore(http.Controller):
 #     @http.route('/maya_core/maya_core', auth='public')
 #     def index(self, **kw):

--- a/models/booking_type.py
+++ b/models/booking_type.py
@@ -41,7 +41,7 @@ class BookingType(models.Model):
         domain="[('model_name', '=', resource_model)]"  
     ) """
 
-    image_url = fields.Image(_('Icono'), max_width=1920, max_height=1920)
+    image_icon = fields.Image(_('Icono'), max_width=1920, max_height=1920)
 
     # computed para mostrar cuántos recursos tiene asociados
     resource_count = fields.Integer(compute='_compute_resource_count')  
@@ -55,9 +55,7 @@ class BookingType(models.Model):
     def _compute_resource_model(self):
       modelo_map = {
           'E': 'maya_core.employee',                    
-          'S': 'maya_core.place',           
-          #'W': 'maya_booking.workstation',       
-          #'I': 'maya_booking.equipment',         
+          'S': 'maya_core.place',              
       }
       for record in self:
         record.resource_model = modelo_map.get(record.resource_type, '')

--- a/models/booking_type.py
+++ b/models/booking_type.py
@@ -41,6 +41,8 @@ class BookingType(models.Model):
         domain="[('model_name', '=', resource_model)]"  
     ) """
 
+    image_url = fields.Image(_('Icono'), max_width=1920, max_height=1920)
+
     # computed para mostrar cuántos recursos tiene asociados
     resource_count = fields.Integer(compute='_compute_resource_count')  
 

--- a/views/views.xml
+++ b/views/views.xml
@@ -45,6 +45,7 @@
             <field name="duration"/>
             <!-- <field name="resource_type"/> -->
             <field name="resource_type" widget="radio" options="{'horizontal': true}"/>
+            <field name="image_url" widget="image" options="{'size': [150, 200], 'zoom': true}" />
             </group>
           </group>
           <notebook>

--- a/views/views.xml
+++ b/views/views.xml
@@ -45,7 +45,7 @@
             <field name="duration"/>
             <!-- <field name="resource_type"/> -->
             <field name="resource_type" widget="radio" options="{'horizontal': true}"/>
-            <field name="image_url" widget="image" options="{'size': [150, 200], 'zoom': true}" />
+            <field name="image_icon" widget="image" options="{'size': [150, 200], 'zoom': true}" />
             </group>
           </group>
           <notebook>


### PR DESCRIPTION
Añadido endpoint /api/booking_types (POST) que devuelve en JSON los tipos de reserva marcados como published. Incluye soporte para imágenes y relaciones.