### PR TITLE
feat: formateado page de reservas en formulario de places con restricciones

### DIFF
--- a/models/booking.py
+++ b/models/booking.py
@@ -28,7 +28,8 @@ class Booking(models.Model):
     booking_resource_id = fields.Many2one(
         comodel_name='maya_booking.booking_resource', 
         string=_("Recurso a reservar"), 
-        required=True
+        required=True,
+        domain="[('is_bookable', '=', True)]" # Oculta recursos no reservables del desplegable
     )
     
     user_id = fields.Many2one(
@@ -179,3 +180,9 @@ class Booking(models.Model):
       ], order='start_time asc')
 
       return sessions.ids
+    
+    @api.constrains('booking_resource_id')
+    def _check_resource_is_bookable(self):
+        for record in self:
+            if record.booking_resource_id and not record.booking_resource_id.is_bookable:
+                raise ValidationError(_("El recurso seleccionado ha sido marcado como 'No Reservable'."))

--- a/models/booking_resource.py
+++ b/models/booking_resource.py
@@ -28,6 +28,27 @@ class BookingResource(models.Model):
   
   resource_name = fields.Char(string="Descripción del recurso", compute="_compute_resource_name", store = True)
 
+  # Nuevo campo espejo (no hace falta mostrarlo en ninguna vista)
+  is_bookable = fields.Boolean(
+      string="Es reservable (Copia)",
+      compute="_compute_is_bookable",
+      store=True,
+      default=True
+  )
+
+  @api.depends('reservable_model', 'reservable_id')
+  def _compute_is_bookable(self):
+      for rec in self:
+          if rec.reservable_model and rec.reservable_id:
+              # Busca el registro físico real
+              real_record = self.env[rec.reservable_model].sudo().browse(rec.reservable_id)
+              if real_record.exists() and 'bookable' in real_record._fields:
+                  rec.is_bookable = real_record.bookable
+              else:
+                  rec.is_bookable = False
+          else:
+              rec.is_bookable = False
+
   @api.model
   def _get_reservable_models(self):
     """

--- a/models/booking_type.py
+++ b/models/booking_type.py
@@ -75,12 +75,11 @@ class BookingType(models.Model):
       """
       Abre la vista timeline desde el kanban
       """
-      self.ensure_one() 
-    
+      self.ensure_one()
       return {
         'name': f'Calendario: {self.name}',
         'type': 'ir.actions.act_window',
-        'res_model': 'maya_booking.booking', 
+        'res_model': 'maya_booking.booking',
         'view_mode': 'timeline,list,form',
         # filtro para mostrar solo las reservas de este tipo de recurso
         'domain': [('booking_resource_id.booking_type_ids.resource_type', '=', self.resource_type)],

--- a/models/reservable_mixin.py
+++ b/models/reservable_mixin.py
@@ -52,7 +52,6 @@ class ReservableMixin(models.AbstractModel):
     def _onchange_bookable_update_last_reservation(self):
         for record in self:
             if not record.bookable and record._origin.id:
-                
                 ref_string = f'{self._name},{record._origin.id}'
                 
                 resource = self.env['maya_booking.booking_resource'].search([
@@ -67,7 +66,10 @@ class ReservableMixin(models.AbstractModel):
                     )
                     
                     if last_booking and last_booking.date_stop:
-                        # RESTAMOS 2 HORAS EXACTAS (ni zonas horarias ni hostias)
+                       # Se le restan dos horas para evitar error de desajuste
                         record.last_reservation_date = last_booking.date_stop - timedelta(hours=2)
                     else:
                         record.last_reservation_date = False
+            
+            else:
+                record.last_reservation_date = False

--- a/models/reservable_mixin.py
+++ b/models/reservable_mixin.py
@@ -33,3 +33,41 @@ class ReservableMixin(models.AbstractModel):
     )
 
     display_name = fields.Char(string="Descripción", compute="_compute_display_name")
+
+    @api.constrains('num_max_session_consecutive', 'max_days_in_advance')
+    def _check_reservation_limits(self):
+        """
+        Restringir cantidad de sesiones consecutivas reservables y días de antelación de la reserva
+        """
+        for record in self:
+            if record.num_max_session_consecutive < 0 or record.num_max_session_consecutive > 11:
+                raise ValidationError(_("El número máximo de sesiones consecutivas debe estar entre 0 y 11."))
+            if record.max_days_in_advance < 0 or record.max_days_in_advance > 90:
+                raise ValidationError(_("Los días de antelación deben estar entre 0 y 90."))
+    
+    @api.onchange('bookable')
+    def _onchange_bookable_update_last_reservation(self):
+        """
+        Calcula la última reserva del recurso cuando deja de ser reservable.
+        Al estar en el mixin, funciona dinámicamente para Espacios, Empleados, etc.
+        """
+        for record in self:
+            if not record.bookable and record._origin.id:
+                
+                # Usamos self._name para que funcione dinámicamente con el modelo 
+                # que hereda el mixin (ej. 'maya_core.place' o 'hr.employee')
+                ref_string = f'{self._name},{record._origin.id}'
+                
+                resource = self.env['maya_booking.booking_resource'].search([
+                    ('reservable_ref', '=', ref_string)
+                ], limit=1)
+
+                if resource:
+                    last_booking = self.env['maya_booking.booking'].search(
+                        [('booking_resource_id', '=', resource.id)],
+                        order='date_start desc',
+                        limit=1
+                    )
+                    
+                    if last_booking and last_booking.date_start:
+                        record.last_reservation_date = last_booking.date_start

--- a/models/reservable_mixin.py
+++ b/models/reservable_mixin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError
+from datetime import timedelta
 
 class ReservableMixin(models.AbstractModel):
     _name = 'maya_booking.reservable.mixin'
@@ -45,17 +46,13 @@ class ReservableMixin(models.AbstractModel):
             if record.max_days_in_advance < 0 or record.max_days_in_advance > 90:
                 raise ValidationError(_("Los días de antelación deben estar entre 0 y 90."))
     
+    
+
     @api.onchange('bookable')
     def _onchange_bookable_update_last_reservation(self):
-        """
-        Calcula la última reserva del recurso cuando deja de ser reservable.
-        Al estar en el mixin, funciona dinámicamente para Espacios, Empleados, etc.
-        """
         for record in self:
             if not record.bookable and record._origin.id:
                 
-                # Usamos self._name para que funcione dinámicamente con el modelo 
-                # que hereda el mixin (ej. 'maya_core.place' o 'hr.employee')
                 ref_string = f'{self._name},{record._origin.id}'
                 
                 resource = self.env['maya_booking.booking_resource'].search([
@@ -65,9 +62,12 @@ class ReservableMixin(models.AbstractModel):
                 if resource:
                     last_booking = self.env['maya_booking.booking'].search(
                         [('booking_resource_id', '=', resource.id)],
-                        order='date_start desc',
+                        order='date_stop desc',
                         limit=1
                     )
                     
-                    if last_booking and last_booking.date_start:
-                        record.last_reservation_date = last_booking.date_start
+                    if last_booking and last_booking.date_stop:
+                        # RESTAMOS 2 HORAS EXACTAS (ni zonas horarias ni hostias)
+                        record.last_reservation_date = last_booking.date_stop - timedelta(hours=2)
+                    else:
+                        record.last_reservation_date = False

--- a/models/reservable_mixin.py
+++ b/models/reservable_mixin.py
@@ -73,3 +73,17 @@ class ReservableMixin(models.AbstractModel):
             
             else:
                 record.last_reservation_date = False
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'bookable' in vals:
+            for record in self:
+                # Buscamos si este recurso físico está enlazado a algún booking_resource. ! Se usa sudo
+                resources = self.env['maya_booking.booking_resource'].sudo().search([
+                    ('reservable_model', '=', self._name),
+                    ('reservable_id', '=', record.id)
+                ])
+                # Actualizamos el campo espejo en la tabla intermedia
+                if resources:
+                    resources.write({'is_bookable': vals['bookable']})
+        return res

--- a/views/views.xml
+++ b/views/views.xml
@@ -76,7 +76,7 @@
         <page string="Reservas">
           <group>
             <group>
-              <field name="bookable" widget="boolean_toggle"/>
+              <field name="bookable"/>
               <field name="last_reservation_date" readonly="1" force_save="1"/>
             </group>
             <group>

--- a/views/views.xml
+++ b/views/views.xml
@@ -77,7 +77,10 @@
           <group>
             <group>
               <field name="bookable"/>
-              <field name="last_reservation_date" readonly="1" force_save="1"/>
+              <field name="last_reservation_date" 
+                readonly="1" 
+                force_save="1" 
+                invisible="bookable"/>
             </group>
             <group>
               <field name="num_max_session_consecutive" 

--- a/views/views.xml
+++ b/views/views.xml
@@ -80,8 +80,13 @@
               <field name="last_reservation_date" readonly="1" force_save="1"/>
             </group>
             <group>
-              <field name="num_max_session_consecutive" readonly="not bookable"/>
-              <field name="max_days_in_advance" readonly="not bookable"/>
+              <field name="num_max_session_consecutive" 
+                    readonly="not bookable" 
+                    options="{'type': 'number', 'step': 1}"/>
+                    
+              <field name="max_days_in_advance" 
+                    readonly="not bookable" 
+                    options="{'type': 'number', 'step': 1}"/>
             </group>
           </group>
         </page>

--- a/views/views.xml
+++ b/views/views.xml
@@ -66,19 +66,23 @@
     </field>
   </record>
 
- <!-- View de place (añadido) --> 
+  <!-- View de place (añadido) --> 
   <record model="ir.ui.view" id="maya_booking.view_place_form_inherit">
     <field name="name">Formulario espacios. Añade reservas</field>
     <field name="model">maya_core.place</field>
     <field name="inherit_id" ref="maya_core.view_place_form"/>
     <field name="arch" type="xml">
       <xpath expr="/form/notebook/page[1]" position="after">
-        <page string = "Reservas">
+        <page string="Reservas">
           <group>
-            <field name="bookable" widget="boolean_toggle"/>
-            <field name="num_max_session_consecutive"/>
-            <field name="max_days_in_advance"/>
-            <field name="last_reservation_date"/>
+            <group>
+              <field name="bookable" widget="boolean_toggle"/>
+              <field name="last_reservation_date" readonly="1" force_save="1"/>
+            </group>
+            <group>
+              <field name="num_max_session_consecutive" readonly="not bookable"/>
+              <field name="max_days_in_advance" readonly="not bookable"/>
+            </group>
           </group>
         </page>
       </xpath>


### PR DESCRIPTION
He modificado la page de Reservas dentro del formulario de places (_inherit) para dejarlo más organizado.

Dentro de reservable_mixin, he añadido una restricción para limitar las sesiones consecutivas y días de antelación, y un onchange en relación a 'bookable' para calcular la última reserva del recurso y almacenarla en 'last_reservation_date'. He cambiado de el switch de bookable a un checkbox simple para evitar errores. Cuando el recurso es reservable se oculta el campo de  'last_reservation_date' y cuando se activa se muestra con ya con la última reserva del recurso.