### PR TITLE
feat: items del timeline estilizados

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -18,6 +18,7 @@
     'assets': {
         'web.assets_backend': [
             'maya_booking/static/src/css/booking_type_kanban.css',
+            'maya_booking/static/src/css/timeline.css',
             'maya_booking/static/src/js/booking_timeline.js',
         ],
     },

--- a/static/src/css/timeline.css
+++ b/static/src/css/timeline.css
@@ -1,0 +1,23 @@
+/* Permitimos que la caja principal desborde y se ponga por encima del resto */
+.o_timeline_view .vis-item {
+    overflow: visible !important;
+    z-index: 1; 
+}
+
+/* Configuramos el contenedor para permitir saltos de línea PERO prohibimos romper palabras */
+.o_timeline_view .vis-item .vis-item-content {
+    white-space: normal !important; 
+    word-break: normal !important; 
+    overflow-wrap: normal !important;
+    
+    overflow: visible !important;
+    line-height: 1.2 !important;
+    display: block !important;
+}
+
+/* Limpiamos las reglas del div interno que acabamos de poner en el XML */
+.o_timeline_view .vis-item .vis-item-content > div {
+    white-space: normal !important;
+    word-break: normal !important;
+    overflow: visible !important;
+}

--- a/views/views.xml
+++ b/views/views.xml
@@ -150,28 +150,32 @@
     <field name="name">maya_booking.booking.timeline</field>
     <field name="model">maya_booking.booking</field>
     <field name="arch" type="xml">
-      <timeline date_start="date_start" 
+        <timeline date_start="date_start" 
                   date_stop="date_stop" 
                   default_group_by="booking_resource_id"
                   group_model="maya_booking.booking_resource"
                   event_open_popup="true"
                   zoomKey="ctrlKey"
                   mode="week"
-  
-                  colors="#FF7F7F: user_id != false;"> 
+                  colors="#946bf3: reason == 'TC'; 
+                          #4f8bec: reason == 'TI'; 
+                          #40c498: reason == 'R'; 
+                          #e05555: reason == 'EX'; 
+                          #e470de: reason == 'O';"> 
           
-        <field name="name"/>
-        <field name="booking_resource_id"/>
-        <field name="user_id"/>
+            <field name="name"/>
+            <field name="booking_resource_id"/>
+            <field name="user_id"/>
+            <field name="reason"/>
 
-        <templates>
-          <t t-name="timeline-item">
-            <div class="o_timeline_item_content" style="padding: 2px;">
-                <t t-esc="(record.user_id ? record.user_id[1] : 'Sistema') + ' - ' + record.name"/>
-            </div>
-          </t>
-        </templates>
-      </timeline>
+            <templates>
+                <t t-name="timeline-item">
+                    <div class="o_timeline_item_content" style="padding: 2px 4px; color: #111827; font-weight: 400;">
+                        <t t-esc="(record.user_id ? record.user_id[1] : 'Sistema') + ' - ' + record.name"/>
+                    </div>
+                </t>
+            </templates>
+        </timeline>
     </field>
   </record>
   


### PR DESCRIPTION
He añadido un condicional en el view timeline del modelo booking para que el fondo del item cambie de color según las opciones disponibles de la variable "reason".

He creado un nuevo archivo css, separado del que se usa para el kanban de booking_type, para que cuando el texto del label sea más largo que el contenedor se haga un salto de línea, sin cortarse las palabras, de manera que quedan varias líneas con un contendor más alto (siempre que sea necesario, si cabe se queda en una sola línea).